### PR TITLE
Fix test image access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- JUnit dependencies -->
+		<dependency>
+			<groupId>org.scijava</groupId>
+			<artifactId>junit-benchmarks</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
+++ b/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
@@ -14,14 +14,23 @@ import net.imglib2.exception.IncompatibleTypeException;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.scijava.util.FileUtils;
 
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+
+@BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 5)
 public class TiffBenchmark {
+
+	/** Needed for JUnit-Benchmarks */
+	@Rule
+	public TestRule benchmarkRun = new BenchmarkRule();
 
 	private static final String IMG1 = "/FakeTracks.tif";
 	private static final String BASENAME = "write_";
-	private static final int NUM_WRITES = 300;
 
 	private File baseDirectory;
 
@@ -51,54 +60,42 @@ public class TiffBenchmark {
 	public void tiffNaiveTest() throws ImgIOException,
 			IncompatibleTypeException, FormatException {
 
-		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".tif").getPath(), m_sfimg);
-		}
+		m_saver.saveImg(new File(baseDirectory, BASENAME + ".tif").getPath(), m_sfimg);
 	}
 
 	@Test
 	public void pngNaiveTest() throws ImgIOException,
 			IncompatibleTypeException, FormatException {
 
-		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".png").getPath(), m_sfimg);
-		}
+		m_saver.saveImg(new File(baseDirectory, BASENAME + ".png").getPath(), m_sfimg);
 	}
 
 	@Test
 	public void epsNaiveTest() throws ImgIOException,
 			IncompatibleTypeException, FormatException {
 
-		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".eps").getPath(), m_sfimg);
-		}
+		m_saver.saveImg(new File(baseDirectory, BASENAME + ".eps").getPath(), m_sfimg);
 	}
 
 	@Test
 	public void icsNaiveTest() throws ImgIOException,
 			IncompatibleTypeException, FormatException {
 
-		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".ics").getPath(), m_sfimg);
-		}
+		m_saver.saveImg(new File(baseDirectory, BASENAME + ".ics").getPath(), m_sfimg);
 	}
 
 	@Test
 	public void jpgNaiveTest() throws ImgIOException,
 			IncompatibleTypeException, FormatException {
 
-		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".jpg").getPath(), m_sfimg);
-		}
+		m_saver.saveImg(new File(baseDirectory, BASENAME + ".jpg").getPath(), m_sfimg);
 	}
 
 //	@Test
 //	public void jp2NaiveTest() throws ImgIOException,
 //			IncompatibleTypeException, FormatException {
 //
-//		for (int i = 0; i < NUM_WRITES; i++) {
-//			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".jp2", m_sfimg);
-//		}
+//		m_saver.saveImg(BASEFOLDER + BASENAME + ".jp2", m_sfimg);
 //	}
 
 }

--- a/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
+++ b/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
@@ -1,13 +1,13 @@
 package org.knime.knip.scifio.profiling;
 
+import static org.junit.Assert.assertTrue;
 import io.scif.FormatException;
 import io.scif.img.ImgIOException;
 import io.scif.img.ImgOpener;
 import io.scif.img.ImgSaver;
 import io.scif.img.SCIFIOImgPlus;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 import java.util.List;
 
 import net.imglib2.exception.IncompatibleTypeException;
@@ -15,13 +15,15 @@ import net.imglib2.exception.IncompatibleTypeException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.scijava.util.FileUtils;
 
 public class TiffBenchmark {
 
-	private static final String BASEFOLDER = "writetest/target/";
-	private static final String IMG1 = "writetest/res/FakeTracks.tif";
+	private static final String IMG1 = "/FakeTracks.tif";
 	private static final String BASENAME = "write_";
 	private static final int NUM_WRITES = 300;
+
+	private File baseDirectory;
 
 	private final ImgSaver m_saver = new ImgSaver();
 	private SCIFIOImgPlus<?> m_sfimg;
@@ -30,19 +32,19 @@ public class TiffBenchmark {
 	public void setup() throws IncompatibleTypeException, ImgIOException {
 
 		// cleanup
-		final Path folder = Paths.get(BASEFOLDER);
-		folder.toFile().delete();
-		folder.toFile().mkdirs();
+		baseDirectory = new File(getClass().getResource("/").getPath(), "../output");
+		FileUtils.deleteRecursively(baseDirectory);
+		assertTrue(baseDirectory.mkdirs());
 
+		final File testImage = new File(getClass().getResource(IMG1).getPath());
 		final ImgOpener opener = new ImgOpener();
-		List<SCIFIOImgPlus<?>> imgs = opener.openImgs(IMG1);
+		List<SCIFIOImgPlus<?>> imgs = opener.openImgs(testImage.getPath());
 		m_sfimg = imgs.get(0);
 	}
 	
 	@After
 	public void cleanup() throws Exception {
-		final Path folder = Paths.get(BASEFOLDER);
-		folder.toFile().delete();
+		FileUtils.deleteRecursively(baseDirectory);
 	}
 
 	@Test
@@ -50,7 +52,7 @@ public class TiffBenchmark {
 			IncompatibleTypeException, FormatException {
 
 		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".tif", m_sfimg);
+			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".tif").getPath(), m_sfimg);
 		}
 	}
 
@@ -59,7 +61,7 @@ public class TiffBenchmark {
 			IncompatibleTypeException, FormatException {
 
 		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".png", m_sfimg);
+			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".png").getPath(), m_sfimg);
 		}
 	}
 
@@ -68,7 +70,7 @@ public class TiffBenchmark {
 			IncompatibleTypeException, FormatException {
 
 		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".eps", m_sfimg);
+			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".eps").getPath(), m_sfimg);
 		}
 	}
 
@@ -77,7 +79,7 @@ public class TiffBenchmark {
 			IncompatibleTypeException, FormatException {
 
 		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".ics", m_sfimg);
+			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".ics").getPath(), m_sfimg);
 		}
 	}
 
@@ -86,7 +88,7 @@ public class TiffBenchmark {
 			IncompatibleTypeException, FormatException {
 
 		for (int i = 0; i < NUM_WRITES; i++) {
-			m_saver.saveImg(BASEFOLDER + BASENAME + i + ".jpg", m_sfimg);
+			m_saver.saveImg(new File(baseDirectory, BASENAME + i + ".jpg").getPath(), m_sfimg);
 		}
 	}
 

--- a/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
+++ b/src/test/java/org/knime/knip/scifio/profiling/TiffBenchmark.java
@@ -1,3 +1,33 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2015 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
 package org.knime.knip.scifio.profiling;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/knime/knip/scifio/profiling/WriteTest.java
+++ b/src/test/java/org/knime/knip/scifio/profiling/WriteTest.java
@@ -53,7 +53,7 @@ import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 
 @BenchmarkOptions(benchmarkRounds = 20, warmupRounds = 5)
-public class TiffBenchmark {
+public class WriteTest {
 
 	/** Needed for JUnit-Benchmarks */
 	@Rule


### PR DESCRIPTION
The test image was moved, but the test code was not adjusted (this developer's fault). This change fixes that.

While at it, avoid the completely unnecessary use of Java 1.7 API.

And we might just as well switch to `junit-benchmarks` right away, too... So now you see something like

```
[...]
TiffBenchmark.tiffNaiveTest: [measured 20 out of 25 rounds, threads: 1 (sequential)]
 round: 0.33 [+- 0.05], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 7, GC.time: 0.02, time.total: 8.86, time.warmup: 2.21, time.bench: 6.65
[...]
TiffBenchmark.epsNaiveTest: [measured 20 out of 25 rounds, threads: 1 (sequential)]
 round: 0.01 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 0.20, time.warmup: 0.05, time.bench: 0.15
```

... which kind of clearly demonstrates the problem we're trying to solve :stuck_out_tongue: 
